### PR TITLE
Feature developer mode

### DIFF
--- a/Fulfillment/Model/Observer.php
+++ b/Fulfillment/Model/Observer.php
@@ -57,8 +57,8 @@ class Whiplash_Fulfillment_Model_Observer extends Varien_Object
         // Set the API credentials
         $api_key = Mage::getStoreConfig('whiplash/api/key'); // Whiplash Sandbox on Testing Server
         $api_version = Mage::getStoreConfig('whiplash/api/version'); // OPTIONAL: Leave this blank to use the most recent API
-		$storeId = $this->getStoreId();
-		$test = Mage::getStoreConfig('whiplash/api/test_mode'); // OPTIONAL: If test is true, this will use your sandbox account
+        $storeId = $this->getStoreId();
+        $test = Mage::getStoreConfig('whiplash/api/test_mode'); // OPTIONAL: If test is true, this will use your sandbox account
 
 		// Include the Whiplash lib and initialize
         $ExternalLibPath=Mage::getBaseDir('code') . DS . 'community' . DS . 'Whiplash' . DS . 'Fulfillment'. DS . 'lib' . DS .'WhiplashApi.php';

--- a/Fulfillment/etc/system.xml
+++ b/Fulfillment/etc/system.xml
@@ -61,6 +61,24 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </test_mode>
+                         <dev_mode translate="label">
+                            <label>Developer Mode</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </dev_mode>
+                        <dev_mode_url translate="label">
+                            <label>Developer Mode URL</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>60</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><dev_mode>1</dev_mode></depends>
+                        </dev_mode_url>
                     </fields>
                 </api>
             </groups>

--- a/Fulfillment/lib/WhiplashApi.php
+++ b/Fulfillment/lib/WhiplashApi.php
@@ -44,6 +44,10 @@ class WhiplashApi extends Varien_Object
 			} else {
 				$this->base_url = 'https://www.getwhiplash.com/api/';
 			}
+      if (Mage::getStoreConfig('whiplash/api/dev_mode') == true) {
+        $this->base_url = Mage::getStoreConfig('whiplash/api/dev_mode_url');
+      }
+
 
 			$ch = curl_init();
     	// Set headers


### PR DESCRIPTION
This adds the option to define a custom base url so requests can be directed to servers outside of Sandbox and Production such as QA or a ngrok tunnel. 

Option to enable Developer Mode:
![Screen Shot 2019-12-11 at 11 44 51 AM](https://user-images.githubusercontent.com/13951892/70641947-67824f80-1c0c-11ea-8f3d-e8204b7ebe95.png)

If enabled set url: 
![Screen Shot 2019-12-11 at 11 51 40 AM](https://user-images.githubusercontent.com/13951892/70642320-ff803900-1c0c-11ea-99c1-4da5b922dee5.png)


